### PR TITLE
React Native 0.49.0 Support

### DIFF
--- a/Example/components/TabIcon.js
+++ b/Example/components/TabIcon.js
@@ -1,6 +1,5 @@
-import React, {
-  PropTypes,
-} from 'react';
+import React from "react";
+import PropTypes from "prop-types";
 import {
   Text,
 } from 'react-native';

--- a/Example/components/TabView.js
+++ b/Example/components/TabView.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import {PropTypes} from "react";
-import {StyleSheet, Text, View} from "react-native";
+import React from "react";
+import PropTypes from "prop-types";
+import {StyleSheet, Text, View, ViewPropTypes} from "react-native";
 import Button from 'react-native-button';
 import { Actions } from 'react-native-router-flux';
 
@@ -10,7 +10,7 @@ const contextTypes = {
 
 const propTypes = {
   name: PropTypes.string,
-  sceneStyle: View.propTypes.style,
+  sceneStyle: ViewPropTypes.style,
   title: PropTypes.string,
 };
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-addons-pure-render-mixin": "15.0.2",
     "react-native-experimental-navigation": "0.26.x",
     "react-native-tabs": "^1.0.9",
     "react-static-container": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     }
   ],
   "dependencies": {
+    "prop-types": "15.6.0",
     "react-addons-pure-render-mixin": "15.0.2",
     "react-native-experimental-navigation": "0.26.x",
     "react-native-tabs": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "prop-types": "15.6.0",
-    "react-native-experimental-navigation": "0.26.x",
+    "react-native-experimental-navigation": "0.29.1",
     "react-native-tabs": "^1.0.9",
     "react-static-container": "1.0.1"
   },

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -16,7 +16,7 @@ import {
   Dimensions,
 } from 'react-native';
 import NavigationExperimental from 'react-native-experimental-navigation';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import {PureComponent} from 'react';
 
 import TabBar from './TabBar';
 import NavBar from './NavBar';
@@ -98,7 +98,7 @@ function leftToRight(/* NavigationSceneRendererProps */ props) {
   };
 }
 
-export default class DefaultRenderer extends Component {
+export default class DefaultRenderer extends PureComponent {
 
   static propTypes = {
     navigationState: PropTypes.object,
@@ -258,8 +258,6 @@ export default class DefaultRenderer extends Component {
 
   constructor(props) {
     super(props);
-
-    this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
   }
 
   getChildContext() {

--- a/src/DefaultRenderer.js
+++ b/src/DefaultRenderer.js
@@ -6,10 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, {
-  Component,
-  PropTypes,
-} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import {
   Animated,
   View,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -1,6 +1,5 @@
-import React, {
-  PropTypes,
-} from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {
   View,
 } from 'react-native';

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -23,9 +23,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-import React, {
-  PropTypes,
-} from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import {
   Platform,
   Animated,

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -34,6 +34,7 @@ import {
   Text,
   TouchableOpacity,
   View,
+  ViewPropTypes,
 } from 'react-native';
 import Actions from './Actions';
 import _drawerImage from './menu_burger.png';
@@ -154,7 +155,7 @@ const propTypes = {
   wrapBy: PropTypes.any,
   component: PropTypes.any,
   backButtonTextStyle: Text.propTypes.style,
-  leftButtonStyle: View.propTypes.style,
+  leftButtonStyle: ViewPropTypes.style,
   leftButtonIconStyle: Image.propTypes.style,
   getTitle: PropTypes.func,
   titleWrapperStyle: Text.propTypes.style,
@@ -162,7 +163,7 @@ const propTypes = {
   titleOpacity: PropTypes.number,
   titleProps: PropTypes.any,
   position: PropTypes.object,
-  navigationBarStyle: View.propTypes.style,
+  navigationBarStyle: ViewPropTypes.style,
   navigationBarBackgroundImage: Image.propTypes.source,
   renderTitle: PropTypes.any,
 };

--- a/src/Router.js
+++ b/src/Router.js
@@ -6,10 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, {
-  Component,
-  PropTypes,
-} from 'react';
+import PropTypes from 'prop-types';
+
+import React, { Component } from 'react';
 import { BackAndroid } from 'react-native';
 import NavigationExperimental from 'react-native-experimental-navigation';
 

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -6,7 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { View, Text } from 'react-native';
 
 export default class extends React.Component {

--- a/src/Scene.js
+++ b/src/Scene.js
@@ -9,19 +9,19 @@
 import PropTypes from 'prop-types';
 
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, ViewPropTypes } from 'react-native';
 
 export default class extends React.Component {
 
   // @todo - should all props be documented/specified here?
 
   static propTypes = {
-    tabBarStyle: View.propTypes.style,
-    tabBarSelectedItemStyle: View.propTypes.style,
-    tabBarIconContainerStyle: View.propTypes.style,
-    tabBarShadowStyle: View.propTypes.style,
-    tabSceneStyle: View.propTypes.style,
-    tabStyle: View.propTypes.style,
+    tabBarStyle: ViewPropTypes.style,
+    tabBarSelectedItemStyle: ViewPropTypes.style,
+    tabBarIconContainerStyle: ViewPropTypes.style,
+    tabBarShadowStyle: ViewPropTypes.style,
+    tabSceneStyle: ViewPropTypes.style,
+    tabStyle: ViewPropTypes.style,
     tabTitleStyle: Text.propTypes.style,
     tabSelectedTitleStyle: Text.propTypes.style,
     tabTitle: PropTypes.string,

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import TabBar from './TabBar';
 import Actions from './Actions';
 

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {
   Image,
   View,

--- a/src/TabbedView.js
+++ b/src/TabbedView.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { View, StyleSheet } from 'react-native';
 import StaticContainer from 'react-static-container';
 

--- a/src/TabbedView.js
+++ b/src/TabbedView.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ViewPropTypes } from 'react-native';
 import StaticContainer from 'react-static-container';
 
 const styles = StyleSheet.create({
@@ -18,7 +18,7 @@ class TabbedView extends Component {
   static propTypes = {
     navigationState: PropTypes.object.isRequired,
     renderScene: PropTypes.func.isRequired,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
   };
 
   constructor(props, context) {


### PR DESCRIPTION
- Use `prop-types` lib rather than React.PropTypes
- Use PureComponent rather than react-addons-pure-render-mixin
- Update to newer react-native-experimental-navigation (which has `prop-types` usage in there).

Note this isn't really for merging.